### PR TITLE
Fix compilation warnings

### DIFF
--- a/lib/thurim/events.ex
+++ b/lib/thurim/events.ex
@@ -37,7 +37,7 @@ defmodule Thurim.Events do
     "state_default" => 50,
     "users_default" => 0
   }
-  @domain Application.get_env(:thurim, :matrix)[:domain]
+  @domain Application.compile_env(:thurim, :matrix)[:domain]
 
   def timeline_for_room_id(room_id, since \\ nil)
 

--- a/lib/thurim/events/event.ex
+++ b/lib/thurim/events/event.ex
@@ -5,7 +5,7 @@ defmodule Thurim.Events.Event do
   alias Thurim.Events.EventStateKey
   alias Thurim.Events
 
-  @domain Application.get_env(:thurim, :matrix)[:domain]
+  @domain Application.compile_env(:thurim, :matrix)[:domain]
 
   @primary_key {:id, :binary_id, autogenerate: true}
   schema "events" do

--- a/lib/thurim/events/event_data.ex
+++ b/lib/thurim/events/event_data.ex
@@ -3,7 +3,7 @@ defmodule Thurim.Events.EventData do
   alias Thurim.Federation.KeyServer
   require Logger
 
-  @domain Application.get_env(:thurim, :matrix)[:domain]
+  @domain Application.compile_env(:thurim, :matrix)[:domain]
 
   def base_pdu(event) do
     %{

--- a/lib/thurim/rooms.ex
+++ b/lib/thurim/rooms.ex
@@ -10,7 +10,7 @@ defmodule Thurim.Rooms do
   alias Thurim.Rooms.RoomAlias
   alias Thurim.Events
 
-  @domain Application.get_env(:thurim, :matrix)[:domain]
+  @domain Application.compile_env(:thurim, :matrix)[:domain]
 
   def generate_room_id() do
     "!" <> UUID.uuid4() <> ":" <> @domain

--- a/lib/thurim/rooms/room.ex
+++ b/lib/thurim/rooms/room.ex
@@ -5,8 +5,8 @@ defmodule Thurim.Rooms.Room do
   alias Thurim.Events.Event
   alias Thurim.Rooms
 
-  @default_room_version Application.get_env(:thurim, :matrix)[:default_room_version]
-  @supported_room_versions Application.get_env(:thurim, :matrix)[:supported_room_versions]
+  @default_room_version Application.compile_env(:thurim, :matrix)[:default_room_version]
+  @supported_room_versions Application.compile_env(:thurim, :matrix)[:supported_room_versions]
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id

--- a/lib/thurim/user.ex
+++ b/lib/thurim/user.ex
@@ -16,7 +16,7 @@ defmodule Thurim.User do
   alias Thurim.PushRules
   alias Thurim.Events
 
-  @domain Application.get_env(:thurim, :matrix)[:domain]
+  @domain Application.compile_env(:thurim, :matrix)[:domain]
 
   def localpart_available?(localpart) do
     get_account(localpart) == nil

--- a/lib/thurim_web/controllers/matrix/client/r0/room_controller.ex
+++ b/lib/thurim_web/controllers/matrix/client/r0/room_controller.ex
@@ -208,7 +208,7 @@ defmodule ThurimWeb.Matrix.Client.R0.RoomController do
 
   def create_redaction(
         conn,
-        %{"room_id" => room_id, "event_id" => event_id, "txn_id" => txn_id} = _params
+        %{"room_id" => room_id, "event_id" => _event_id, "txn_id" => txn_id} = _params
       ) do
     account = Map.fetch!(conn.assigns, :current_account)
     sender = Map.fetch!(conn.assigns, :sender)

--- a/lib/thurim_web/controllers/matrix/well_known_controller.ex
+++ b/lib/thurim_web/controllers/matrix/well_known_controller.ex
@@ -1,7 +1,7 @@
 defmodule ThurimWeb.Matrix.WellKnownController do
   use ThurimWeb, :controller
 
-  @homeserver_url Application.get_env(:thurim, :matrix)[:homeserver_url]
+  @homeserver_url Application.compile_env(:thurim, :matrix)[:homeserver_url]
 
   def client(conn, _params) do
     json(conn, %{

--- a/lib/thurim_web/plugs/interactive_auth.ex
+++ b/lib/thurim_web/plugs/interactive_auth.ex
@@ -6,7 +6,7 @@ defmodule ThurimWeb.Plugs.InteractiveAuth do
   require Logger
   import Phoenix.Controller, only: [json: 2]
 
-  @matrix_config Application.get_env(:thurim, :matrix)
+  @matrix_config Application.compile_env(:thurim, :matrix)
   @flows @matrix_config[:auth_flows]
 
   def init(options), do: options


### PR DESCRIPTION
On Elixir 1.14.0:

```
warning: Application.get_env/2 is discouraged in the module body, use Application.compile_env/3 instead
  lib/thurim/events/event_data.ex:6: Thurim.Events.EventData

warning: Application.get_env/2 is discouraged in the module body, use Application.compile_env/3 instead
  lib/thurim/events/event.ex:8: Thurim.Events.Event

warning: Application.get_env/2 is discouraged in the module body, use Application.compile_env/3 instead
  lib/thurim/events.ex:40: Thurim.Events

warning: Application.get_env/2 is discouraged in the module body, use Application.compile_env/3 instead
  lib/thurim/rooms.ex:13: Thurim.Rooms

warning: Application.get_env/2 is discouraged in the module body, use Application.compile_env/3 instead
  lib/thurim/rooms/room.ex:8: Thurim.Rooms.Room

warning: Application.get_env/2 is discouraged in the module body, use Application.compile_env/3 instead
  lib/thurim/rooms/room.ex:9: Thurim.Rooms.Room

warning: Application.get_env/2 is discouraged in the module body, use Application.compile_env/3 instead
  lib/thurim/user.ex:19: Thurim.User

warning: Application.get_env/2 is discouraged in the module body, use Application.compile_env/3 instead
  lib/thurim_web/plugs/interactive_auth.ex:9: ThurimWeb.Plugs.InteractiveAuth

warning: Application.get_env/2 is discouraged in the module body, use Application.compile_env/3 instead
  lib/thurim_web/controllers/matrix/client/r0/user_controller.ex:10: ThurimWeb.Matrix.Client.R0.UserController

warning: Application.get_env/2 is discouraged in the module body, use Application.compile_env/3 instead
  lib/thurim_web/controllers/matrix/well_known_controller.ex:4: ThurimWeb.Matrix.WellKnownController

warning: variable "event_id" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/thurim_web/controllers/matrix/client/r0/room_controller.ex:211: ThurimWeb.Matrix.Client.R0.RoomController.create_redaction/2
```