### PR TITLE
Document X.509 certificate generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Thurim is developed against:
 After cloning the repo:
 
 * Install dependencies with `mix deps.get`
+* Create self-signed X.509 certificate: `mkdir -p priv/cert/; openssl req -x509 -newkey rsa:4096 -keyout priv/cert/selfsigned_key.pem -out priv/cert/selfsigned.pem -sha256 -days 365 -nodes`
 * Create and migrate your database with `mix ecto.setup`
 * Start Phoenix endpoint with `mix phx.server`
 


### PR DESCRIPTION
Without a cert there, it crashes on startup with:

```
** (Mix) Could not start application thurim: Thurim.Application.start(:normal, []) returned an error: shutdown: failed to start child: ThurimWeb.Endpoint
    ** (EXIT) an exception was raised:
        ** (ArgumentError) could not start Cowboy2 adapter, the file /home/dev-thurim/thurim/_build/dev/lib/thurim/priv/cert/selfsigned_key.pem required by SSL's :keyfile either does not exist, or the application does not have permission to access it
            (plug_cowboy 2.5.2) lib/plug/cowboy.ex:386: Plug.Cowboy.fail/1
            (plug_cowboy 2.5.2) lib/plug/cowboy.ex:144: Plug.Cowboy.args/4
            (plug_cowboy 2.5.2) lib/plug/cowboy.ex:238: Plug.Cowboy.child_spec/1
            (phoenix 1.6.8) lib/phoenix/endpoint/cowboy2_adapter.ex:86: Phoenix.Endpoint.Cowboy2Adapter.child_spec/3
            (phoenix 1.6.8) lib/phoenix/endpoint/cowboy2_adapter.ex:66: anonymous fn/5 in Phoenix.Endpoint.Cowboy2Adapter.child_specs/2
            (elixir 1.14.0) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
            (phoenix 1.6.8) lib/phoenix/endpoint/cowboy2_adapter.ex:56: Phoenix.Endpoint.Cowboy2Adapter.child_specs/2
            (phoenix 1.6.8) lib/phoenix/endpoint/supervisor.ex:68: Phoenix.Endpoint.Supervisor.init/1
            (stdlib 4.2) supervisor.erl:330: :supervisor.init/1
            (stdlib 4.2) gen_server.erl:851: :gen_server.init_it/2
            (stdlib 4.2) gen_server.erl:814: :gen_server.init_it/6
            (stdlib 4.2) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
```